### PR TITLE
Add baseURL parameter to hugo config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,3 +1,4 @@
+baseURL = "https://inclusivenaming.org"
 title = "Inclusive Naming Initiative"
 disableKinds = ["taxonomy", "taxonomyTerm"]
  copyright = "The Inclusive Naming Initiative authors and collaborating organizations"


### PR DESCRIPTION
It seems that https://github.com/inclusivenaming/website/blob/576e9b6479e79eb7737f430434d22ead55bd04cb/layouts/partials/navbar.html#L1 is actually unset, and as such, when you click the logo it is linking to the current page (empty href), rather than the actual homepage.