### PR TITLE
Clarify how to join the mailinglist (without Google account)

### DIFF
--- a/content/get-involved.md
+++ b/content/get-involved.md
@@ -5,6 +5,7 @@ title: "Get involved"
 ## Participate!
 
 **Join the mailing list:** [inclusivenaming@googlegroups.com](https://groups.google.com/g/inclusivenaming)
+Send a mail to <inclusivenaming+subscribe@googlegroups.com> if you want to use a non Google email address.
 
 **Join the Bi-weekly meeting: Mondays @ 9:15 Pacific Time**: you can get an invitation via the mailing list!
 


### PR DESCRIPTION
# Situation

when I try to join the mailinglist, I actually made a mistake: I just sent a mail with my introduction. However, that wasn't a subscription to the mailinglist of course. I realized that later as I didn't get any further mails.

Neither the Google help nor the [about page](https://groups.google.com/g/inclusivenaming/about) tells you how to subscribe without a Google account (for obvious reasons). This information is missing in the homepage of INI.

# Suggested Solution

This pull request adds just a small little sentence to send a mail to `<inclusivenaming+subscribe@googlegroups.com>`. Some people could already familiar, but others are not. So this helps to avoid issues and speed up things.

Of course, feel free to improve wording etc.

