### PR TITLE
Add workstream info and public calendar

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -67,7 +67,26 @@ weight = 2
 
 [[menu.main]]
 name = "Get involved"
-url = "/get-involved"
+url = "#"
+weight = 3
+identifier = "getinvolved"
+
+[[menu.main]]
+name = "Participate"
+url = "/participate"
+parent = "getinvolved"
+weight = 1
+
+[[menu.main]]
+name = "Workstreams"
+url = "/workstreams"
+parent = "getinvolved"
+weight = 2
+
+[[menu.main]]
+name = "Meeting calendar"
+url = "/calendar"
+parent = "getinvolved"
 weight = 3
 
 [[menu.main]]

--- a/content/calendar.md
+++ b/content/calendar.md
@@ -1,0 +1,8 @@
+---
+title: Calendar 
+---
+
+To receive invitations to meetings on this calendar, join the Inclusive Naming Initiative's mailing list at [inclusivenaming@googlegroups.com](https://groups.google.com/g/inclusivenaming).
+
+
+{{< calendar >}}

--- a/content/participate.md
+++ b/content/participate.md
@@ -1,5 +1,5 @@
 ---
-title: "Get involved"
+title: "Participate"
 ---
 
 ## Participate!

--- a/content/workstreams.md
+++ b/content/workstreams.md
@@ -1,0 +1,74 @@
+---
+title: Workstreams
+---
+
+The Inclusive Naming Initiative does its work in a set of workstreams which focus on specific subject areas. 
+
+# Cross-cutting workstreams
+
+These workstreams support the work of the domain-specific workstreams by producing recommendations as well as driving community and marketing efforts.
+
+## Community workstream
+
+Handles community intake, managing donated projects and wording recommendations, and system administration.
+
+**Leads (interim):** Stephen Augustus 
+
+**Meeting times:** See the [calendar](/calendar)
+
+**Communication methods:** Inclusive naming initiative slack: #ws-community, [ws-community@inclusivenaming.org](ws-community@inclusivenaming.org) 
+
+
+## Marketing workstream
+
+Handles marketing, events, and membership for the Inclusive Naming Initiative.
+
+**Leads:** Bill Mulligan, Priyanka Sharma
+
+**Meeting times:** See the [calendar](/calendar)
+
+**Communication methods:** Inclusive naming initiative slack: #ws-marketing, [ws-marketing@inclusivenaming.org](ws-marketing@inclusivenaming.org) 
+
+## Language workstream
+
+Researches inclusive language and produces recommendations to remove insensitive terminology. 
+
+**Leads:** Celeste Horgan, Larry Kunz 
+
+**Meeting times:** See the [calendar](/calendar)
+
+**Communication methods:** Inclusive naming initiative slack: #ws-language, [ws-language@inclusivenaming.org](ws-language@inclusivenaming.org) 
+
+# Domain-specific workstreams
+
+These workstreams create advice and guidance for working on inclusive naming efforts in specific contexts, such as individual companies or open source projects.
+
+## Company
+
+Develops guidance for open source projects and maintainers executing inclusive naming work.
+
+**Leads:** André Pellet, Monica Rush
+
+**Meeting times:** See the [calendar](/calendar)
+
+**Communication methods:** Inclusive naming initiative slack: #ws-company, [ws-company@inclusivenaming.org](ws-company@inclusivenaming.org) 
+
+## Standards organizations
+
+Works with standards bodies and organizations that work with them on driving inclusive naming work.
+
+**Leads:** Joanne Lee, Matthew Schnoor  
+
+**Meeting times:** See the [calendar](/calendar)
+
+**Communication methods:** Inclusive naming initiative slack: #ws-standards, [ws-standards@inclusivenaming.org](ws-standards@inclusivenaming.org) 
+
+## Open source 
+
+Develops guidance for open source projects and maintainers executing inclusive naming work.
+
+**Leads:** Stephen Augustus, Celeste Horgan 
+
+**Meeting times:** See the [calendar](/calendar)
+
+**Communication methods:** Inclusive naming initiative slack: #ws-oss, [ws-oss@inclusivenaming.org](ws-oss@inclusivenaming.org) 

--- a/layouts/shortcodes/calendar.html
+++ b/layouts/shortcodes/calendar.html
@@ -1,0 +1,1 @@
+<iframe src="https://calendar.google.com/calendar/embed?src=c_87cqvdudltvfsk2ko8l80finug%40group.calendar.google.com&ctz=America%2FVancouver" style="border: 0" width="800" height="600" frameborder="0" scrolling="no"></iframe>


### PR DESCRIPTION
Signed-off-by: Celeste Horgan <celeste@cncf.io>

Partially closes #36.

Preview Links:

https://deploy-preview-37--inclusivenaming.netlify.app/participate/ (was "Get Involved")
https://deploy-preview-37--inclusivenaming.netlify.app/workstreams/ (new)
https://deploy-preview-37--inclusivenaming.netlify.app/calendar/ (new) 