### PR TITLE
add: linkedin url to the site

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -23,6 +23,11 @@ url = "https://twitter.com/inclusivenaming"
 icon = "fab fa-twitter"
 
 [[params.social]]
+name = "LinkedIn"
+url = "https://www.linkedin.com/company/inclusive-naming/"
+icon = "fab fa-linkedin-in"
+
+[[params.social]]
 name = "GitHub"
 url = "https://github.com/inclusivenaming"
 icon = "fab fa-github"

--- a/content/participate.md
+++ b/content/participate.md
@@ -11,7 +11,7 @@ Send a mail to <inclusivenaming+subscribe@googlegroups.com> if you want to use a
 
 **Join the Bi-weekly meeting: Mondays @ 9:15 Pacific Time**: you can get an invitation via the mailing list!
 
-You can also follow us on Twitter: [@inclusivenaming](https://twitter.com/inclusivenaming).
+You can also follow us on Twitter: [@inclusivenaming](https://twitter.com/inclusivenaming) and [LinkedIN](https://www.linkedin.com/company/inclusive-naming/)
 
 ## Get your company involved 
 


### PR DESCRIPTION
Signed-off-by: gkarthiks <github.gkarthiks@gmail.com>

This PR adds the link to the *Inclusive Naming Initiative* LinkedIn page.

Fixes: #63 

/cc @justaugustus 