### PR TITLE
Add link to the official HUGO installation document in README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ This repository uses:
 
 ## Running locally
 
-Make sure you have [npm](https://www.npmjs.com/) and [yarn](https://yarnpkg.com/) installed. Clone this repository and run the following two commands in its directory:
+Make sure you have [Hugo website engine](https://gohugo.io/getting-started/installing/), [npm](https://www.npmjs.com/) and [yarn](https://yarnpkg.com/) installed. Clone this repository and run the following two commands in its directory:
 
 ```shell
 # Install npm assets


### PR DESCRIPTION
Add link to the official `HUGO installation document` in `README.md `to clearly explain all the steps required to run the INI website locally. 