### PR TITLE
Add Hugo devcontainer with brief README

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,31 @@
+# Update the NODE_VERSION arg in docker-compose.yml to pick a Node version: 10, 12, 14
+ARG NODE_VERSION=14
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node:${NODE_VERSION}
+
+# VARIANT can be either 'hugo' for the standard version or 'hugo_extended' for the extended version.
+ARG VARIANT=hugo
+# VERSION can be either 'latest' or a specific version number
+ARG VERSION=latest
+
+# Download Hugo
+RUN apt-get update && apt-get install -y ca-certificates openssl git curl && \
+    rm -rf /var/lib/apt/lists/* && \
+    case ${VERSION} in \
+    latest) \
+    export VERSION=$(curl -s https://api.github.com/repos/gohugoio/hugo/releases/latest | grep "tag_name" | awk '{print substr($2, 3, length($2)-4)}') ;;\
+    esac && \
+    echo ${VERSION} && \
+    wget -O ${VERSION}.tar.gz https://github.com/gohugoio/hugo/releases/download/v${VERSION}/${VARIANT}_${VERSION}_Linux-64bit.tar.gz && \
+    tar xf ${VERSION}.tar.gz && \
+    mv hugo /usr/bin/hugo
+
+# Hugo dev server port
+EXPOSE 1313
+
+# [Optional] Uncomment this section to install additional OS packages you may want.
+#
+# RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+#     && apt-get -y install --no-install-recommends <your-package-list-here>
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN sudo -u node npm install -g <your-package-list-here>

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -2,7 +2,7 @@
 
 ## What is a Development Container?
 
-* Learn more about [using a Docker container as a development environment in VSCode](https://code.visualstudio.com/docs/remote/containers).
+* Learn more about [using a Docker container as a development environment in VS Code](https://code.visualstudio.com/docs/remote/containers).
 * Learn more about [using a Docker container as a development environment with GitHub Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace).
 
 ## Contents

--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,0 +1,10 @@
+# Inclusive Naming Initiative Website Development Container
+
+## What is a Development Container?
+
+* Learn more about [using a Docker container as a development environment in VSCode](https://code.visualstudio.com/docs/remote/containers).
+* Learn more about [using a Docker container as a development environment with GitHub Codespaces](https://docs.github.com/en/codespaces/developing-in-codespaces/creating-a-codespace).
+
+## Contents
+
+Based on the [Hugo dev container template](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/hugo) from the `vscode-dev-containers` GitHub repository.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,38 @@
+{
+	"name": "Hugo (Community)",
+	"build": {
+		"dockerfile": "Dockerfile",
+		"args": {
+			// Update VARIANT to pick hugo variant.
+			// Example variants: hugo, hugo_extended
+			// Rebuild the container if it already exists to update.
+			"VARIANT": "hugo_extended",
+			// Update VERSION to pick a specific hugo version.
+			// Example versions: latest, 0.73.0, 0,71.1
+			// Rebuild the container if it already exists to update.
+			"VERSION": "latest",
+			// Update NODE_VERSION to pick the Node.js version: 12, 14
+			"NODE_VERSION": "14",
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": {},
+	
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"bungcip.better-toml",
+		"davidanson.vscode-markdownlint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [
+		1313
+	],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	// "postCreateCommand": "uname -a",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node"
+}


### PR DESCRIPTION
Adds files to use VSCode/GitHub Codespaces devcontainers with this project. Directly based on the [Hugo dev container template](https://github.com/microsoft/vscode-dev-containers/tree/main/containers/hugo).

At current I haven't pinned Hugo to a specific version and it just uses `latest` as the project README doesn't specify a version.

This addition helps make the project more approachable and quick to get started with, and allows devs to work without local installs of tooling they may otherwise not use often.