### PR TITLE
Adding Sophisticated issue form for media mentions

### DIFF
--- a/.github/ISSUE_TEMPLATE/media_mention.yml
+++ b/.github/ISSUE_TEMPLATE/media_mention.yml
@@ -1,0 +1,27 @@
+name: Media Mentions
+description: Create an issue to add media mentions of the INI
+title: "[Media Mentions] Issue Title"
+labels: [documentation]
+assignees:
+  - gkarthiks
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to let us know about the Media Mention of Inclusive Naming Intitiative. This helps us in keeping the website up-to-date.
+
+  - type: textarea
+    id: media
+    attributes:
+      label: What's the name of the site/media that has mentioned the Inclusive Naming Initiative?
+      description: For example `New York Times`.
+    validations:
+      required: true
+
+  - type: input
+    id: media-link
+    attributes:
+      label: What is the URL to the article that has mentioned/featured the INI?
+      placeholder: Copy paste the entire URL from the browser tab that has the article opened.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/media_mention.yml
+++ b/.github/ISSUE_TEMPLATE/media_mention.yml
@@ -8,7 +8,7 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thanks for taking the time to let us know about the Media Mention of Inclusive Naming Intitiative. This helps us in keeping the website up-to-date.
+        Thanks for taking the time to let us know about the Media Mention of Inclusive Naming Initiative. This helps us in keeping the website up-to-date.
 
   - type: textarea
     id: media


### PR DESCRIPTION
This PR will add a sophisticated issue form for prompting the details about the media/site that mentions or features the Inclusive Naming Initiative. This will help in collecting the details of the site and add it to the list of mentions on our website.

The issue form looks like the below.

![image](https://user-images.githubusercontent.com/30545166/128625419-84393949-ee35-4221-a67c-d169e7e8d2e0.png)


When clicked on `Get Started`, 

![image](https://user-images.githubusercontent.com/30545166/128625433-7ae7933c-7456-4e9e-892c-1b67c5a61041.png)


By default, this assigns to me, as I will update the list. But the reporter can assign to anyone.

/cc @xmulligan @celestehorgan 