### PR TITLE
Replace PR 89 with this one

### DIFF
--- a/content/blog/_posts/mark-miller-llnl-interview.md
+++ b/content/blog/_posts/mark-miller-llnl-interview.md
@@ -1,0 +1,76 @@
+---
+title: "Moving the needle on inclusive language. Mark Miller"
+date: 2021-09-08
+slug: inclusive-language-inititives-lll
+author: Oshrat Nir, Mark Miller
+---
+
+
+# Moving the needle on inclusive language, with Mark Miller of Lawrence Livermore National Lab.
+
+Welcome back to our series **Moving the Needle on inclusive language**. In this series, we talk to leaders in the cloud native space as they share the inclusive naming
+initiatives they care about. This will include tools, activities, and results they have discovered along the way.
+
+[Mark Miller](https://people.llnl.gov/miller86) works at the Lawrence Livermore National Laboratory. He contributes to the development of visualization
+tools used to analyze data from very large simulations. Mark is the first member of a USDOE national lab to participate in the Inclusive Naming Initiative as opposed to most
+of the other contributors who are with commercial companies or academia.
+
+**As a white male engineer, what got you interested in inclusive language? What triggered your involvement?**
+I don't have many real life events in which non-inclusive language has presented a barrier to me, as I am at the top of the privilege spectrum. That being said, November 9th 2016 was
+a turning point for me (the day Donald Trump became president-elect). That day something shifted for me. To that point I had been aware that there
+were issues, but I had taken the approach that simply being a good person and striving to treat everyone the same was sufficient. That day I decided that this was no way near enough and
+that I had to become actively involved. I  had to be a part of moving the needle on issues of racism and other biases like gender or ableism. Sitting on the sidelines and
+waiting for others to solve the problem was not the answer. Especially since this leaves the oppressed to deal with things on their own. Solving this problem requires all hands on
+deck.
+
+Over the last four years I have spent the majority of the time learning. Part of this has involved participating in a book club. A small group of us at Livermore Labs decided
+to start reading [Me and white supremacy by Layla Saad](https://www.meandwhitesupremacybook.com/) and going through the exercises in it. Every chapter introduces a concept
+and asks several questions. In the club we ask ourselves these questions and then share our answers. The reason I joined is that *White Supremacy* was in the title and I think we
+need to name what is really a key root cause.
+
+The term white supremacy brings to mind very extreme and violent manifestations. These still happen and cannot be tolerated. That being said, the biggest problem is talking
+about and addressing how much a white supremacy ideology permeates our culture. It is a problem that affects the thinking of both the oppressors and the oppressed. 
+
+Reading the book and doing the exercises have helped me acknowledge these problems. I have also gotten more comfortable talking about them. Something useful that has come
+out of it is my ability to recognize and name things that are fundamental to the problem like Tone policing, Tokenization or White Saviorism.
+
+**Do you think inclusive naming initiatives should happen top-down or bottom-up?**
+My sense is grassroots, bottom-up is the way to do it. INI started with and still includes a significant proportion of white male faces. Lately, we have been seeing more different people
+join. My thought is - what we want to do is great, but we can’t act without the authority of the groups that are affected by this language. We would like to see members of
+these groups giving a stamp of approval in some way. This could be either by direct interaction. It can also take the form of providing consultation, guidance or
+recommendations. We need to find some way to encourage that representation involved in the process. Otherwise, it’s more of the same. People who don’t experience the problems
+trying to make arguments for changing language they assume is harmful and the inclusive replacements they came up with. Whereas, the community that is affected would be able to
+clearly state what is in fact an issue and what is not.
+
+**What steps have you taken to eliminate bias from the language you use at Livermore Labs? What will keep the initiative moving forward?**
+Apart from the book club, we are focusing on language in software projects. The most egregious example in the tech community that you may often hear used is Master-Slave.
+It has been used for decades and the discourse about changing it started as early as the [mid-90s](https://www.jstor.org/stable/40061475).
+
+I have actually written code that used that terminology. I have worked with code that used that terminology. I have probably written related documentation that uses that
+terminology. All the while, it never dawned on me that this is problematic language.
+
+Over the last 18 months or so, developers in two of DOE's flagship simulation projects (Ale3d at LLNL and Sierra at SNL) have taken up the effort to rid their codebases of that language. I interviewed
+people on both code teams and learned about that process. Managers in these projects had wanted to see this language change for many years. The problem
+was that they were lacking the credibility with the code teams to advocate for investing the effort to make the change. The public discourse in the last year and a half around the George Floyd murder and the
+Black Lives Matter movement created an environment in which it was easy to get buy-in for changing this language.
+
+Once they decided that they were going to do it, it turned out to be more work than they had anticipated, because of how much it affects things. Finding replacement
+terminology that everybody agreed with was hard. Even harder was finding all the places in the code, in the documentation, in data files, etc.
+It was more effort than originally anticipated. While it was supported by management, these efforts did come with additional funding. As a result the teams had to
+set aside other tasks in order to make these language changes.
+
+You tend to think it’s just find and replace, but in code it’s more than that. In order to get rid of derivatives of this terminology (for example variable names and
+acronyms). Automated tools can help but a thorough job does require human eyeballs and manual review by the developers. In one of the projects this involved replacements in a code base of about a million lines
+and several thousand source files. Ultimately, this initiative impacted ~10,00 lines and ~2,000 source files. In addition users of the interfaces need to be educated on the replacement terms
+applied in the code, so they can continue to use it properly. So, there’s training too.
+
+**How do you account for diversity in your organization?**
+The computation department at Livermore Labs has many women in management. Overall, we have maybe 40% women. I think we do well with female gender representation. That
+being said, we have a lot of work to do when it comes to ethnic representation.
+
+>I always wondered, “why somebody doesn’t do something about that?" then I realized I was somebody  ~ Lily Tomlin
+
+In this interview, Mark Miller acknowledged his privilege and shared what he was doing about changing the status quo. Racial and gender equity is foremost on his agenda and he is
+working from the bottom up to be part of the change he wants to see.
+
+If you’d like to be featured or know someone who’d be a great fit you can find us on Twitter @inclusivenaming and spread the love.


### PR DESCRIPTION
@Oshratn and @celestehorgan 

This PR should replace #89. Close #89 and work from this one instead.

- renames file correctly to `mark-miller-llnl-interview.md`
- fixes incorrect links in original
- various minor revisions for accuracy/clarity

I originally made proposed revisions [here](https://github.com/Oshratn/website/pull/1). There is no expectation on my part that @Oshratn accept *all* changes here...only those addressing inaccuracies. Sorry I didn't think to separate those from a second commit for clarity. If you would prefer that, lemme know.