### PR TITLE
Fix broken header link and add missing link

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -119,7 +119,7 @@ weight = 5
 
 [[menu.main]]
 name = "Word replacement list"
-url = "/language/word-list"
+url = "/word-lists/overview"
 parent = "lang"
 weight = 1
 

--- a/content/word-lists/overview.md
+++ b/content/word-lists/overview.md
@@ -2,17 +2,17 @@
 title: "Overview"
 ---
 
-# Language recommendation lists 
+# Language recommendation lists
 
 The Inclusive Naming Initiative produces three tiers of language recommendation. These are compiled into lists for easy consumption by adopters. Terms are separated into lists based on the severity of the term in question as well as the level of review the terms have received.
 
 ## Tier 1: Replace Immediately
 
-Tier 1 terms should be replaced whenever encountered. 
-Terms included in this list have one or all of the following: 
+[Tier 1 terms](tier-1) should be replaced whenever encountered.
+Terms included in this list have one or all of the following:
 
 - Strong social consensus within the software development community on replacements
-- Are identified by the Inclusive Naming Initiative as high-severity terms in need of immediate replacement 
+- Are identified by the Inclusive Naming Initiative as high-severity terms in need of immediate replacement
 - Terms where the impact of change or removal is low: for example, there is little entanglement in low-level systems or standardized language set by standards bodies
 - Have passed through all the review stages in Tiers 2 and 3
 
@@ -21,14 +21,14 @@ Terms included in this list have one or all of the following:
 Terms in this list should be replaced whenever possible, barring major breaking changes.
 Terms included in this list have one or all of the following:
 
-- Are terms from Tier 3 that have undergone through external review by underrepresented minority groups and outside consultants 
+- Are terms from Tier 3 that have undergone through external review by underrepresented minority groups and outside consultants
 - Terms which would otherwise be in Tier 1 but have dependencies on language set by standards bodies, or are deeply embedded in low-level systems and thus difficult to change
 
 ## Tier 3: Recommendations to Replace
 
-Terms in this list should be considered for replacement. 
+Terms in this list should be considered for replacement.
 Terms included in this list have one or all of the following:
 
 - Review by the Inclusive Naming Initiative, with particular attention paid to finding consensus among member companies and participants' companies for replacements
-- Research conducted by the Inclusive Naming Initiative on the etymology of the word and non-tech cultural connotations, per the [Language Evaluation Framework](https://inclusivenaming.org/language/evaluation-framework/)
+- Research conducted by the Inclusive Naming Initiative on the etymology of the word and non-tech cultural connotations, per the [Language Evaluation Framework](/language/evaluation-framework/)
 - A consensus-based replacement term or terms proposed by the Language Workstream and sent for approval and review to the larger Initiative


### PR DESCRIPTION
Hi, I'm really a fan of the project; I just ran across it today and found an issue in the menu.

---

Since #92 was merged, the link in the header no longer works.
I also added a link the Tier 1 list from the overview, since
I'm not sure sure how else to get there. I didn't want to make
more intrusive changes, like changing the text in the menu entry
or adding a link directly to the Tier 1 list, without further
discussion.

---

Sorry, there are a bunch of extraneous whitespace changes that were added by my editor. I can remove them if desired.