### PR TITLE
Improve cripple page

### DIFF
--- a/content/word-lists/tier-1/_cripple.md
+++ b/content/word-lists/tier-1/_cripple.md
@@ -28,11 +28,10 @@ use_context: "N/A"
 recommendation: "Adopt immediately."
 
 recommended_replacements:
-    - Impact
+    - Impacted
     - Degraded
-    - Restrict
-    - Immobilize
-    - Examples of replacement
+    - Restricted
+    - Immobilized
 
 unsuitable_replacements:
     - None
@@ -53,8 +52,8 @@ rationale: |
     - Crippled functionality
         - Restricted
     - Security issues cripple an organization
-        - Impact
-        - Immobilize
+        - Impacted
+        - Immobilized
     - Crippleware
         - Software with restricted functionality
 status: | 


### PR DESCRIPTION
Removes the incorrectly placed 'Examples of replacement' text, and makes the tense of the words consistent to improve readability.