### PR TITLE
use blackbox written together consistently

### DIFF
--- a/content/word-lists/no-change/blackbox.md
+++ b/content/word-lists/no-change/blackbox.md
@@ -12,7 +12,7 @@ related_terms:
     - whitebox
 definition: "N/A"
 use_context: "An abstraction of a device or system in which only its externally visible behavior is considered and not its implementation or inner workings."
-recommendation: "No change recommended. This term may be used without restriction. Black box refers to opacity, such as details that aren't visible or are not the focus. This term is not based on a good/bad binary where white is represented as good or black is represented as bad and so does not promote racial bias."
+recommendation: "No change recommended. This term may be used without restriction. Blackbox refers to opacity, such as details that aren't visible or are not the focus. This term is not based on a good/bad binary where white is represented as good or black is represented as bad and so does not promote racial bias."
 recommended_replacements:
     - None
 unsuitable_replacements:

--- a/content/word-lists/no-change/whitebox.md
+++ b/content/word-lists/no-change/whitebox.md
@@ -9,7 +9,7 @@ outputs:
 tier: 0
 term: "whitebox"
 related_terms:
-    - black box
+    - blackbox
 definition: |
     From [Wikipedia](https://en.wikipedia.org/wiki/White-box_testing):
 


### PR DESCRIPTION
I noticed that in some places `blackbox` was used and in others `black box`. But it does raise the question if some rules should have aliases, since one can see also `black-box` and `black box` being used.