### PR TITLE
please don't imply neurodiversity is just mental health issues

### DIFF
--- a/content/word-lists/tier-2/sanity-check.md
+++ b/content/word-lists/tier-2/sanity-check.md
@@ -23,7 +23,7 @@ recommended_replacements:
 unsuitable_replacements:
     - N/A
 rationale: |
-    This term might be derogatory to neurodiverse people. Jargon, such as "sanity test", is difficult to translate and is difficult to understand by readers whose first language is not English.
+    This term might be derogatory to people with mental health issues. Jargon, such as "sanity test", is difficult to translate and is difficult to understand by readers whose first language is not English.
 
     Note: The original recommendation via IBM’s Words Matter group included different recommendations, but INI liked [Twitter’s recommendations][twitter-recs] of "confidence check" and "coherence check" and have opted to use them instead.
 status: | 


### PR DESCRIPTION
Neurodiversity includes autism, ADHD, dyslexia etc which are not classified as mental health conditions like schizophrenia, psychosis, etc.  Whether mental health issues can be regarded as a subset of neurodiversity might be an open question, but by saying "derogatory to neurodiverse people" without qualifying that only some types are meant, the document could be taken to imply that all neurodiversity is mental health issues, which is not correct.