### PR TITLE
Fix: Alphabetize glossary list and remove empty list item

### DIFF
--- a/content/word-lists/no-change/blackout.md
+++ b/content/word-lists/no-change/blackout.md
@@ -8,7 +8,7 @@ outputs:
     - custom
 
 tier: 0
-term: "Blackout"
+term: "blackout"
 related_terms:
     - None
 definition: "N/A"

--- a/content/word-lists/template.md
+++ b/content/word-lists/template.md
@@ -1,5 +1,6 @@
 ---
-title: WordList Template
+title: "WordList Template"
+ignore: true
 ---
 
 The Hugo software used to build this website uses Frontmatter of each page to determine how to process each page. The Wordlist section of this website uses the frontmatter to generate the pages for each Worlist term and the JSON file containing all of them. To ensure consistency, the template below has been created. It is based on YAML.

--- a/content/word-lists/tier-1/tribe.md
+++ b/content/word-lists/tier-1/tribe.md
@@ -9,7 +9,7 @@ outputs:
 
 
 tier: 1
-term: "Tribe"
+term: "tribe"
 related_terms:
     - N/A
 definition: "N/A"

--- a/content/word-lists/tier-3/segregate.md
+++ b/content/word-lists/tier-3/segregate.md
@@ -9,7 +9,7 @@ outputs:
 
 
 tier: 3
-term: "Segregate"
+term: "segregate"
 related_terms:
     - All Derivatives
     - Segregation

--- a/layouts/partials/docs/section-nav_wordlist.html
+++ b/layouts/partials/docs/section-nav_wordlist.html
@@ -2,7 +2,7 @@
 <nav class="section-nav">
   <h3>Terms Glossary</h3>
   {{ if .IsSection}}
-  {{ range .RegularPagesRecursive }}
+  {{ range where .RegularPagesRecursive "Params.ignore" "!=" "true" }}
             <li>
                 <a style="font-size: large;" href="{{.Permalink}}">{{.Params.term}}</a>
             </li>

--- a/layouts/partials/docs/section-nav_wordlist.html
+++ b/layouts/partials/docs/section-nav_wordlist.html
@@ -4,7 +4,7 @@
   {{ if .IsSection}}
   {{ range where .RegularPagesRecursive "Params.ignore" "!=" "true" }}
             <li>
-                <a style="font-size: large;" href="{{.Permalink}}">{{.Params.term}}</a>
+                <a style="font-size: large;" href="{{.Permalink}}">{{ title .Params.term}}</a>
             </li>
    {{ end }}
    {{ end }}


### PR DESCRIPTION
Should make this easier to read and removes a bug where there's an empty `<li>` item caused by trying to add all pages in the dir. 