### PR TITLE
Add redirection from broken link

### DIFF
--- a/static/_redirects
+++ b/static/_redirects
@@ -1,2 +1,2 @@
-/language/word-list                  /word-lists/overview
-/word-lists/overview                  /word-lists
+/language/word-list                  /word-lists
+/word-lists/overview                 /word-lists

--- a/static/_redirects
+++ b/static/_redirects
@@ -1,1 +1,2 @@
 /language/word-list                  /word-lists/overview
+/word-lists/overview                  /word-lists


### PR DESCRIPTION
The link from word-lists overview is broken, and it's linked from external sources now.
Add redirection to the correct page

https://inclusivenaming.org/word-lists/overview