### PR TITLE
Fix grammar and typos

### DIFF
--- a/.github/ISSUE_TEMPLATE/media_mention.yml
+++ b/.github/ISSUE_TEMPLATE/media_mention.yml
@@ -1,5 +1,5 @@
 name: Media Mentions
-description: Create an issue to add Inclusive Naming Initiatve media mentions
+description: Create an issue to add Inclusive Naming Initiative media mentions
 title: "[Media Mentions] Issue Title"
 labels: [documentation]
 assignees:

--- a/content/blog/monique-umphrey-hcc-interview.md
+++ b/content/blog/monique-umphrey-hcc-interview.md
@@ -50,7 +50,7 @@ We are also doing quite a bit in terms of faculty from an iterative perspective.
 institution is kept abreast of trends, such as inclusive language. In this way we all work to create an environment where everyone feels safe and supported. 
 
 We have a weekly series at our college called a virtual coffee break on Friday. In it we encourage different people across the college to share and lead things from their
-particular perspective. It can be from an LBTQ+ point of view or from our diverse cultural groups. It allows us to share different perspectives to help us to understand
+particular perspective. It can be from an LGBTQ+ point of view or from our diverse cultural groups. It allows us to share different perspectives to help us to understand
 each other’s backgrounds.
 
 **How do you account for diversity in your organization?**
@@ -71,8 +71,7 @@ focus on ensuring that the messages that we're sharing are received as they are 
 
 > "For me, words are a form of action, capable of influencing change."  ~ Ingrid Bengis
 
-In this interview, I found a fearless advocate of inclusive language. Dr Monique Umphrey, withstood the challenges of a difficult and unaccepting environment in her
-college years. After overcoming this and becoming a prominent woman in technology, she is now paying it forward. She is working on creating an intentionally inclusive
+In this interview, I found a fearless advocate of inclusive language. Dr. Monique Umphrey withstood the challenges of a difficult and unaccepting environment in her college years. After overcoming this and becoming a prominent woman in technology, she is now paying it forward. She is working on creating an intentionally inclusive
 environment at Houston Community College and creating access to careers in technology for underprivileged groups.
 
 If you’d like to be featured or know someone who’d be a great fit you can find us on Twitter @inclusivenaming and spread the love.

--- a/content/handbook/evaluation-framework.md
+++ b/content/handbook/evaluation-framework.md
@@ -62,14 +62,14 @@ See also the
 
 - Does the term have militaristic connotations? 
 - Does the term or phrase have historical use either inside or outside technology contexts that someone can easily identity? - Did it arise during a world war, for example?
-- Is the term classist or otherwise segregational? 
+- Is the term classist or otherwise discriminatory?
 - Is the term strongly associated with one gender?
 
 # Third-order concerns 
 
 - The term is unclear, uses metaphor, or a more precise word is available.
 - The term anthropomorphizes (ascribes human traits to nonhuman objects) code or computer systems
-- The language is idomatic, and understanding is limited to those in a particular culture or in-group
+- The language is idiomatic, and understanding is limited to those in a particular culture or in-group
 
 ## Questions to ask
 

--- a/content/handbook/how-we-work.md
+++ b/content/handbook/how-we-work.md
@@ -2,17 +2,17 @@
 title: "How the INI community works"
 ---
 
-The Inclusive Naming Initiative understands the diversity of our community, thats why we constantly iterate our processes to make it easier to join the community and contribute. We are mostly an asynchronous community, which means we only meet once a month during our Monthly Contributors sync, while contributors work at their pace using our [Work plan sheet](https://docs.google.com/spreadsheets/d/1rf4HbPA7nTyrpGByioyKvdJIfZCbBLSEI67_Nf9M6dA/edit?gid=0#gid=0). Below is the process flow:
+The Inclusive Naming Initiative understands the diversity of our community, that's why we constantly iterate our processes to make it easier to join the community and contribute. We are mostly an asynchronous community, which means we only meet once a month during our Monthly Contributors sync, while contributors work at their pace using our [Work plan sheet](https://docs.google.com/spreadsheets/d/1rf4HbPA7nTyrpGByioyKvdJIfZCbBLSEI67_Nf9M6dA/edit?gid=0#gid=0). Below is the process flow:
 
 - A member of the public uses the [Term submission form](https://forms.gle/rj3kWuvAtMJAYRWe8) to suggest a term
 - A Google Doc is created with details of the submission.
 - Contributors are notified and the Term is recorded in the Work Plan [Terms sheet](https://docs.google.com/spreadsheets/d/1rf4HbPA7nTyrpGByioyKvdJIfZCbBLSEI67_Nf9M6dA/edit?gid=0#gid=0).
-- Contributors review and make comments on the submission, in line with the [Language evelaution priciples and framework](/handbook/evaluation-framework/).
+- Contributors review and make comments on the submission, in line with the [Language evaluation principles and framework](/handbook/evaluation-framework/).
 - After 3 to 5 (or more) reviews are received and there is a consensus on the next action to take, the term is either published or archived.
 
 ## Tasks
 
-In the Work plan spreadsheet, we maintain a list of [voluntary tasks](https://docs.google.com/spreadsheets/d/1rf4HbPA7nTyrpGByioyKvdJIfZCbBLSEI67_Nf9M6dA/edit?gid=1508334315#gid=1508334315) that can be carried out by any member of the contributors. These tasks can be any thing from a term review, GitHub issues triage, updates to the webiste or any other necessary task. Contributors can also add tasks they think would be beneficial to the initiative and any other contributor with bandwidth can take it on.
+In the Work plan spreadsheet, we maintain a list of [voluntary tasks](https://docs.google.com/spreadsheets/d/1rf4HbPA7nTyrpGByioyKvdJIfZCbBLSEI67_Nf9M6dA/edit?gid=1508334315#gid=1508334315) that can be carried out by any member of the contributors. These tasks can be any thing from a term review, GitHub issues triage, updates to the website or any other necessary task. Contributors can also add tasks they think would be beneficial to the initiative and any other contributor with bandwidth can take it on.
 
 The Tasks sheet is central to our activities, its where contributors see where they can contribute. Do you want to contribute? Join as a [contributor](https://forms.gle/wkaqTmhvSwgPn69t7) today.
 

--- a/content/outreach.md
+++ b/content/outreach.md
@@ -64,7 +64,7 @@ connotations, or communicate more clearly to non-native speakers.
 
 While a large part of this initiative is, of course, removing offensive
 or otherwise problematic phrasing, it's also about all of those things -
-carefully, intentionally, consciusly selecting words and phrases that
+carefully, intentionally, consciously selecting words and phrases that
 are the best possible ones to communicate the concepts.
 
 ### Tell success stories, giving credit appropriately

--- a/content/word-lists/template.md
+++ b/content/word-lists/template.md
@@ -3,7 +3,7 @@ title: "WordList Template"
 ignore: true
 ---
 
-The Hugo software used to build this website uses Frontmatter of each page to determine how to process each page. The Wordlist section of this website uses the frontmatter to generate the pages for each Worlist term and the JSON file containing all of them. To ensure consistency, the template below has been created. It is based on YAML.
+The Hugo software used to build this website uses Frontmatter of each page to determine how to process each page. The Wordlist section of this website uses the frontmatter to generate the pages for each Wordlist term and the JSON file containing all of them. To ensure consistency, the template below has been created. It is based on YAML.
 
 We you are creating a Pull Request for a new term, copy the template from the first `---` to the last one, make sure to include both `---`.
 

--- a/generateDocFormats.sh
+++ b/generateDocFormats.sh
@@ -3,7 +3,7 @@
 doindent()
 {
   # Do a small indent depending on how deep into the tree we are
-  # Depending on your enviroment, you may need to use
+  # Depending on your environment, you may need to use
   # echo "  \c" instead of
   # echo -en "  "
     j=0;


### PR DESCRIPTION
This pull request includes several changes focused on correcting typographical errors and improving the clarity of documentation. The most important changes are grouped by theme and listed below:

### Typographical Corrections:

* Fixed a typo in the description of the `.github/ISSUE_TEMPLATE/media_mention.yml` file.
* Corrected the spelling of "LGBTQ+" in `content/blog/monique-umphrey-hcc-interview.md`.
* Corrected the spelling of "Dr." in `content/blog/monique-umphrey-hcc-interview.md`.
* Fixed the spelling of "discriminatory" and "idiomatic" in `content/handbook/evaluation-framework.md`.
* Corrected the spelling of "that's" and "evaluation" in `content/handbook/how-we-work.md`.
* Fixed the spelling of "consciously" in `content/outreach.md`.
* Corrected the spelling of "Wordlist" in `content/word-lists/template.md`.
* Fixed the spelling of "environment" in `generateDocFormats.sh`.